### PR TITLE
feat: default to job token to authenticate with GitHub API

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,8 +22,6 @@ jobs:
         uses: ./
         with:
           version: ${{ matrix.version }}
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Test the CLI
         run: exo version
   test-authenticated:
@@ -46,7 +44,5 @@ jobs:
           account: ${{ secrets.EXOSCALE_ACCOUNT }}
           key: ${{ secrets.EXOSCALE_KEY }}
           secret: ${{ secrets.EXOSCALE_SECRET }}
-        env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       - name: Test the CLI
         run: exo config list

--- a/README.md
+++ b/README.md
@@ -100,29 +100,6 @@ Install the latest version of the Exoscale CLI and authenticate it.
   run: exo vm list
 ```
 
-## Caveats
-
-This action makes HTTP requests to the GitHub REST API to determine the URL of
-the assets to download. By default, these requests are made anonymously,
-which means that they are subject to harsher rate limits.
-
-> GitHub-hosted **macOS** runners are typically subject to this issue, because
-> most of them share a common IP address, which increases the likelihood of
-> hitting the rate limit.
-
-If you encounter rate limiting issues, try setting the `GITHUB_TOKEN`
-environment variable to authenticate the requests and increase the
-[rate limit][rate-limit].
-
-[rate-limit]: https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
-
-```yaml
-- name: Setup Exoscale CLI
-  uses: nhedger/setup-exoscale@v1
-  env:
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-```
-
 ## License
 
 The scripts and documentation in this project are licensed under

--- a/action.yaml
+++ b/action.yaml
@@ -5,6 +5,10 @@ branding:
   color: white
   icon: terminal
 inputs:
+  token:
+    description: GitHub Actions token to authenticate API requests
+    required: true
+    default: ${{ github.token }}
   version:
     description: The version of the Exoscale CLI to install
     required: true

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -13352,7 +13352,7 @@ const findAsset = async (releaseId, options) => {
 };
 const install = async (archivePath, options) => {
   const pathToCLI = options.platform === "win32" ? await (0,tool_cache.extractZip)(archivePath) : await (0,tool_cache.extractTar)(archivePath);
-  if (options.platform === "darwin") {
+  if (options.platform === "darwin" && !await (0,promises_namespaceObject.stat)((0,external_path_.join)(pathToCLI, "exo")).catch(() => false)) {
     await (0,promises_namespaceObject.symlink)((0,external_path_.join)(pathToCLI, "exoscale-cli"), (0,external_path_.join)(pathToCLI, "exo"));
   }
   (0,core.addPath)(pathToCLI);
@@ -13389,9 +13389,7 @@ const authenticate = async (options) => {
     version: (0,core.getInput)("version"),
     platform: process.platform,
     octokit: new dist_node/* Octokit */.v({
-      ...(process.env.GITHUB_TOKEN || (0,core.getInput)("GITHUB_TOKEN")) && {
-        auth: (await (0,auth_action_dist_node/* createActionAuth */.C)()()).token
-      }
+      auth: (await (0,auth_action_dist_node/* createActionAuth */.C)()()).token
     }),
     authentication: {
       authenticate: (0,core.getInput)("authenticate") === "true",

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,9 +8,7 @@ import { createActionAuth } from '@octokit/auth-action';
         version: getInput('version'),
         platform: process.platform as 'linux' | 'darwin' | 'win32',
         octokit: new Octokit({
-            ...((process.env.GITHUB_TOKEN || getInput('GITHUB_TOKEN')) && {
-                auth: (await createActionAuth()()).token,
-            }),
+            auth: (await createActionAuth()()).token,
         }),
         authentication: {
             authenticate: getInput('authenticate') === 'true',


### PR DESCRIPTION
This PR:

- [x] Adds a new `token` input that can be used to pass a custom `GITHUB_TOKEN` to authenticate with the GitHub API. By default, it is set to the job token `github.token`.

Fixes #3 