### PR TITLE
chore(dev-deps): pin `@types/node` to `16.18.31`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+    - dependency-name: "@types/node"
+      update-types: ["semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "devDependencies": {
     "@hedger/prettier-config": "^1.2.0",
     "@octokit/types": "^9.2.0",
-    "@types/node": "^18.16.3",
+    "@types/node": "^16.18.31",
     "@vercel/ncc": "^0.36.1",
     "prettier": "^2.8.8",
     "unbuild": "^1.2.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,8 +28,8 @@ devDependencies:
     specifier: ^9.2.0
     version: 9.2.0
   '@types/node':
-    specifier: ^18.16.3
-    version: 18.16.3
+    specifier: ^16.18.31
+    version: 16.18.31
   '@vercel/ncc':
     specifier: ^0.36.1
     version: 0.36.1
@@ -758,8 +758,8 @@ packages:
     resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
     dev: true
 
-  /@types/node@18.16.3:
-    resolution: {integrity: sha512-OPs5WnnT1xkCBiuQrZA4+YAV4HEJejmHneyraIaxsbev5yCEr6KMwINNFP9wQeFIw8FWcoTqF3vQsa5CDaI+8Q==}
+  /@types/node@16.18.31:
+    resolution: {integrity: sha512-KPXltf4z4g517OlVJO9XQ2357CYw7fvuJ3ZuBynjXC5Jos9i+K7LvFb7bUIwtJXSZj0vTp9Q6NJBSQpkwwO8Zw==}
     dev: true
 
   /@types/resolve@1.20.2:


### PR DESCRIPTION
This PR:

- [x] Downgrades `@types/node` to `16.18.31`
- [x] Asks dependabot to ignore new semver-major version of `@types/node`

Fixes #4 