### PR TITLE
feat!: implement automatic authentication

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -38,7 +38,6 @@ jobs:
       - name: Setup Exoscale CLI
         uses: ./
         with:
-          authenticate: true
           zone: ch-gva-2
           version: ${{ matrix.version }}
           account: ${{ secrets.EXOSCALE_ACCOUNT }}

--- a/README.md
+++ b/README.md
@@ -24,32 +24,27 @@ The following inputs are supported.
     # Example values: "1.67.0", "latest"
     version: "latest"
 
-    # Whether to authenticate the Exoscale CLI.
-    # This input is optional and defaults to "false".
-    # Example values: "true", "false"
-    authenticate: false
-
     # The default Exoscale zone to use when authenticating the CLI.
     # This input is optional and defaults to "ch-gva-2".
-    # This input is required if "authenticate" is set to "true".
+    # This input is required to authenticate the Exoscale CLI.
     # Example values: "ch-gva-2", "de-fra-1"
     zone: "<exoscale-zone>"
 
     # The Exoscale account to use when authenticating the CLI.
     # This input is optional.
-    # This input is required if "authenticate" is set to "true".
+    # This input is required to authenticate the Exoscale CLI.
     # Example value: "my-account"
     account: "<exoscale-account-name>"
 
     # The Exoscale API key to use when authenticating the CLI.
     # This input is optional.
-    # This input is required if "authenticate" is set to "true".
+    # This input is required to authenticate the Exoscale CLI.
     # Example value: "EXOb7e97b99f76e32d36351792f"
     key: "<exoscale-api-key>"
 
     # The Exoscale API secret to use when authenticating the CLI.
     # This input is optional.
-    # This input is required if "authenticate" is set to "true".
+    # This input is required to authenticate the Exoscale CLI.
     # Example value: "yftnYtkmylaguBIkTGslohShq5wKHLEtcTGQbGGBGxY"
     secret: "<exoscale-api-secret>"
 
@@ -95,7 +90,6 @@ Install the latest version of the Exoscale CLI and authenticate it.
 - name: Setup Exoscale CLI
   uses: nhedger/setup-exoscale@v1
   with:
-    authenticate: true
     account: my-account
     zone: ch-gva-2
     key: ${{ secrets.EXOSCALE_KEY }}

--- a/action.yaml
+++ b/action.yaml
@@ -13,9 +13,6 @@ inputs:
     description: The version of the Exoscale CLI to install
     required: true
     default: latest
-  authenticate:
-    description: Authenticate the Exoscale CLI
-    required: false
   account:
     description: The Exoscale account name
     required: false

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -13401,8 +13401,7 @@ const install = async (archivePath, options) => {
   (0,core.addPath)(pathToCLI);
 };
 const authenticate = async (options) => {
-  if (Object.entries(options.authentication ?? {}).some(([, value]) => value === void 0)) {
-    console.log(options.authentication);
+  if (Object.entries(options.authentication ?? {}).some(([, value]) => !value)) {
     (0,core.info)("Not authenticating the Exoscale CLI as no authentication options were provided.");
     return;
   }

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -13318,9 +13318,7 @@ const setup = async (config) => {
   try {
     const archivePath = await download(options);
     await install(archivePath, options);
-    if (options.authentication?.authenticate) {
-      await authenticate(options);
-    }
+    await authenticate(options);
   } catch (error) {
     console.log(error);
     (0,core.setFailed)(error.message);
@@ -13404,10 +13402,7 @@ const install = async (archivePath, options) => {
 };
 const authenticate = async (options) => {
   if (Object.entries(options.authentication).some(([, value]) => !value)) {
-    throw new Error(`
-            Cannot authenticate the Exoscale CLI without all authentication options.
-            Please provide the following options: account, zone, key, secret.
-        `);
+    (0,core.info)("Not authenticating the Exoscale CLI as no authentication options were provided.");
   }
   const { account, zone, key, secret } = options.authentication;
   const configFile = `defaultaccount = "${account}"

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -13406,6 +13406,7 @@ const authenticate = async (options) => {
     return;
   }
   const { account, zone, key, secret } = options.authentication;
+  (0,core.info)(`Authenticating the Exoscale CLI as ${account}.`);
   const configFile = `defaultaccount = "${account}"
 [[accounts]]
   account = "${account}"

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -13401,8 +13401,10 @@ const install = async (archivePath, options) => {
   (0,core.addPath)(pathToCLI);
 };
 const authenticate = async (options) => {
-  if (Object.entries(options.authentication).some(([, value]) => !value)) {
+  if (Object.entries(options.authentication ?? {}).some(([, value]) => value === void 0)) {
+    console.log(options.authentication);
     (0,core.info)("Not authenticating the Exoscale CLI as no authentication options were provided.");
+    return;
   }
   const { account, zone, key, secret } = options.authentication;
   const configFile = `defaultaccount = "${account}"
@@ -13424,19 +13426,22 @@ const authenticate = async (options) => {
   (0,core.exportVariable)("EXOSCALE_ACCOUNT", account);
 };
 
+const getInput = (name) => {
+  return (0,core.getInput)(name) === "" ? void 0 : (0,core.getInput)(name);
+};
+
 (async () => {
   await setup({
-    version: (0,core.getInput)("version"),
+    version: getInput("version"),
     platform: process.platform,
     octokit: new dist_node/* Octokit */.v({
       auth: (await (0,auth_action_dist_node/* createActionAuth */.C)()()).token
     }),
     authentication: {
-      authenticate: (0,core.getInput)("authenticate") === "true",
-      account: (0,core.getInput)("account"),
-      zone: (0,core.getInput)("zone"),
-      key: (0,core.getInput)("key"),
-      secret: (0,core.getInput)("secret")
+      account: getInput("account"),
+      zone: getInput("zone"),
+      key: getInput("key"),
+      secret: getInput("secret")
     }
   });
 })();

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,0 +1,5 @@
+import {getInput as coreGetInput} from "@actions/core";
+
+export const getInput = (name: string): string | undefined => {
+    return coreGetInput(name) === '' ? undefined : coreGetInput(name);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { setup } from './setup';
 import { Octokit } from '@octokit/rest';
-import { getInput } from '@actions/core';
+import { getInput as coreGetInput } from '@actions/core';
 import { createActionAuth } from '@octokit/auth-action';
+import { getInput } from "./helpers";
 
 (async () => {
     await setup({
@@ -11,7 +12,6 @@ import { createActionAuth } from '@octokit/auth-action';
             auth: (await createActionAuth()()).token,
         }),
         authentication: {
-            authenticate: getInput('authenticate') === 'true',
             account: getInput('account'),
             zone: getInput('zone'),
             key: getInput('key'),
@@ -19,3 +19,5 @@ import { createActionAuth } from '@octokit/auth-action';
         },
     });
 })();
+
+

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -184,6 +184,7 @@ const install = async (archivePath: string, options: SetupOptions) => {
 const authenticate = async (options: SetupOptions) => {
     if (Object.entries(options.authentication!).some(([, value]) => !value || value === '')) {
         info('Not authenticating the Exoscale CLI as no authentication options were provided.');
+        return;
     }
 
     const { account, zone, key, secret } = options.authentication!;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -2,7 +2,7 @@ import { basename, join } from 'path';
 import { Octokit } from '@octokit/rest';
 import { symlink, writeFile, stat } from 'fs/promises';
 import { RequestError } from '@octokit/request-error';
-import { addPath, exportVariable, setFailed } from '@actions/core';
+import {addPath, exportVariable, info, setFailed} from '@actions/core';
 import { downloadTool, extractTar, extractZip } from '@actions/tool-cache';
 
 /**
@@ -23,9 +23,6 @@ export interface SetupOptions {
      * Authentication options
      */
     authentication?: {
-        /** Whether to authenticate the Exoscale CLI. */
-        authenticate: boolean;
-
         /** Name of the Exoscale account to use. */
         account: string;
 
@@ -62,9 +59,7 @@ export const setup = async (config: Partial<SetupOptions>) => {
         await install(archivePath, options);
 
         // Authenticate the Exoscale CLI
-        if (options.authentication?.authenticate) {
-            await authenticate(options);
-        }
+        await authenticate(options);
     } catch (error: any) {
         console.log(error);
         setFailed(error.message);
@@ -188,10 +183,7 @@ const install = async (archivePath: string, options: SetupOptions) => {
  */
 const authenticate = async (options: SetupOptions) => {
     if (Object.entries(options.authentication!).some(([, value]) => !value)) {
-        throw new Error(`
-            Cannot authenticate the Exoscale CLI without all authentication options.
-            Please provide the following options: account, zone, key, secret.
-        `);
+        info('Not authenticating the Exoscale CLI as no authentication options were provided.');
     }
 
     const { account, zone, key, secret } = options.authentication!;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -182,8 +182,7 @@ const install = async (archivePath: string, options: SetupOptions) => {
  * Authenticates the Exoscale CLI.
  */
 const authenticate = async (options: SetupOptions) => {
-    if (Object.entries(options.authentication ?? {}).some(([, value]) => value === undefined)) {
-        console.log(options.authentication)
+    if (Object.entries(options.authentication ?? {}).some(([, value]) => !value)) {
         info('Not authenticating the Exoscale CLI as no authentication options were provided.');
         return;
     }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -12,7 +12,7 @@ export interface SetupOptions {
     /**
      * Version of the exoscale CLI to download
      */
-    version: string;
+    version?: string;
 
     /**
      * Operating system to download the CLI for
@@ -24,16 +24,16 @@ export interface SetupOptions {
      */
     authentication?: {
         /** Name of the Exoscale account to use. */
-        account: string;
+        account?: string;
 
         /** Name of the default Exoscale zone to use. */
-        zone: string;
+        zone?: string;
 
         /** Exoscale API key. */
-        key: string;
+        key?: string;
 
         /** Exoscale API secret. */
-        secret: string;
+        secret?: string;
     };
 
     /**
@@ -182,7 +182,7 @@ const install = async (archivePath: string, options: SetupOptions) => {
  * Authenticates the Exoscale CLI.
  */
 const authenticate = async (options: SetupOptions) => {
-    if (Object.entries(options.authentication!).some(([, value]) => !value || value === '')) {
+    if (Object.entries(options.authentication!).some(([, value]) => !value)) {
         info('Not authenticating the Exoscale CLI as no authentication options were provided.');
         return;
     }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -182,7 +182,7 @@ const install = async (archivePath: string, options: SetupOptions) => {
  * Authenticates the Exoscale CLI.
  */
 const authenticate = async (options: SetupOptions) => {
-    if (Object.entries(options.authentication!).some(([, value]) => !value)) {
+    if (Object.entries(options.authentication!).some(([, value]) => !value || value === '')) {
         info('Not authenticating the Exoscale CLI as no authentication options were provided.');
     }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -182,7 +182,8 @@ const install = async (archivePath: string, options: SetupOptions) => {
  * Authenticates the Exoscale CLI.
  */
 const authenticate = async (options: SetupOptions) => {
-    if (Object.entries(options.authentication!).some(([, value]) => !value)) {
+    if (Object.entries(options.authentication ?? {}).some(([, value]) => value === undefined)) {
+        console.log(options.authentication)
         info('Not authenticating the Exoscale CLI as no authentication options were provided.');
         return;
     }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -189,6 +189,8 @@ const authenticate = async (options: SetupOptions) => {
 
     const { account, zone, key, secret } = options.authentication!;
 
+    info(`Authenticating the Exoscale CLI as ${account}.`);
+
     const configFile =
         `defaultaccount = "${account}"\n` +
         '[[accounts]]\n' +


### PR DESCRIPTION
This PR removes the `authenticate` input to simplify the usage of this setup action. From now on, the Exoscale CLI will be authenticated automatically whenever the `account`, `key`, `secret` and `zone` inputs have been provided.

### Breaking changes

- The `authenticate` input is removed.
- The CLI now authenticates automatically when possible.